### PR TITLE
Added methods onDraggableCanceled and onDragEnd

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -63,7 +63,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,21 +80,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.8"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -106,56 +106,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.5"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.17"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.9.0-14.0.dev <3.0.0"
-  flutter: ">=1.17.0 <2.0.0"
+  dart: ">=2.12.0-0.0 <3.0.0"
+  flutter: ">=1.17.0"

--- a/lib/devdrag.dart
+++ b/lib/devdrag.dart
@@ -22,60 +22,63 @@ class DragAndDropGridView extends MainGridView {
   /// this [onReorder] have the old index and new index. Called when an acceptable piece of data was dropped over this grid child.
   /// [onWillAccept] this funciton allows you to validate if you want to accept the change in the order of the gridViewItems.
   ///  If you always want to accept the change simply return true
-  DragAndDropGridView({
-    Key key,
-    bool reverse = false,
-    Widget header,
-    ScrollController controller,
-    bool primary,
-    ScrollPhysics physics,
-    bool isCustomFeedback = false,
-    bool isCustomChildWhenDragging = false,
-    @required Function onWillAccept,
-    @required Function onReorder,
-    EdgeInsetsGeometry padding,
-    @required SliverGridDelegate gridDelegate,
-    @required IndexedWidgetBuilder itemBuilder,
-    int itemCount,
-    bool addAutomaticKeepAlives = true,
-    bool addRepaintBoundaries = true,
-    bool addSemanticIndexes = true,
-    double cacheExtent,
-    int semanticChildCount,
-    DragStartBehavior dragStartBehavior = DragStartBehavior.start,
-    ScrollViewKeyboardDismissBehavior keyboardDismissBehavior =
-        ScrollViewKeyboardDismissBehavior.manual,
-    Function feedback,
-    Function childWhenDragging,
-  })  : assert(itemBuilder != null &&
+  DragAndDropGridView(
+      {Key key,
+      bool reverse = false,
+      Widget header,
+      ScrollController controller,
+      bool primary,
+      ScrollPhysics physics,
+      bool isCustomFeedback = false,
+      bool isCustomChildWhenDragging = false,
+      @required Function onWillAccept,
+      @required Function onReorder,
+      EdgeInsetsGeometry padding,
+      @required SliverGridDelegate gridDelegate,
+      @required IndexedWidgetBuilder itemBuilder,
+      int itemCount,
+      bool addAutomaticKeepAlives = true,
+      bool addRepaintBoundaries = true,
+      bool addSemanticIndexes = true,
+      double cacheExtent,
+      int semanticChildCount,
+      DragStartBehavior dragStartBehavior = DragStartBehavior.start,
+      ScrollViewKeyboardDismissBehavior keyboardDismissBehavior =
+          ScrollViewKeyboardDismissBehavior.manual,
+      Function feedback,
+      Function childWhenDragging,
+      Function(DraggableDetails) onDragEnd,
+      Function(Velocity, Offset) onDraggableCanceled})
+      : assert(itemBuilder != null &&
             gridDelegate != null &&
             onReorder != null &&
             onWillAccept != null),
         super(
-          key: key,
-          reverse: reverse,
-          header: header,
-          itemBuilder: itemBuilder,
-          onWillAccept: onWillAccept,
-          feedback: feedback,
-          onReorder: onReorder,
-          childWhenDragging: childWhenDragging,
-          controller: controller,
-          padding: padding,
-          semanticChildCount: semanticChildCount,
-          physics: physics,
-          addAutomaticKeepAlives: addAutomaticKeepAlives,
-          addRepaintBoundaries: addRepaintBoundaries,
-          addSemanticIndexes: addSemanticIndexes,
-          cacheExtent: cacheExtent,
-          itemCount: itemCount,
-          primary: primary,
-          isCustomFeedback: isCustomFeedback,
-          isCustomChildWhenDragging: isCustomChildWhenDragging,
-          gridDelegate: gridDelegate,
-          dragStartBehavior: dragStartBehavior,
-          keyboardDismissBehavior: keyboardDismissBehavior,
-        );
+            key: key,
+            reverse: reverse,
+            header: header,
+            itemBuilder: itemBuilder,
+            onWillAccept: onWillAccept,
+            feedback: feedback,
+            onReorder: onReorder,
+            childWhenDragging: childWhenDragging,
+            controller: controller,
+            padding: padding,
+            semanticChildCount: semanticChildCount,
+            physics: physics,
+            addAutomaticKeepAlives: addAutomaticKeepAlives,
+            addRepaintBoundaries: addRepaintBoundaries,
+            addSemanticIndexes: addSemanticIndexes,
+            cacheExtent: cacheExtent,
+            itemCount: itemCount,
+            primary: primary,
+            isCustomFeedback: isCustomFeedback,
+            isCustomChildWhenDragging: isCustomChildWhenDragging,
+            gridDelegate: gridDelegate,
+            dragStartBehavior: dragStartBehavior,
+            keyboardDismissBehavior: keyboardDismissBehavior,
+            onDragEnd: onDragEnd,
+            onDraggableCanceled: onDraggableCanceled);
 
   /// This constructor  use to achive the Horizontal Reorderable / Re-Indexing feature in DragAndDropGridView.
   /// Providing a non-null `itemCount` improves the ability of the [GridView] to
@@ -94,59 +97,62 @@ class DragAndDropGridView extends MainGridView {
   /// this [onReorder] have the old index and new index. Called when an acceptable piece of data was dropped over this grid child.
   /// [onWillAccept] this funciton allows you to validate if you want to accept the change in the order of the gridViewItems.
   ///  If you always want to accept the change simply return true
-  DragAndDropGridView.horizontal({
-    Key key,
-    bool reverse = false,
-    ScrollController controller,
-    bool primary,
-    ScrollPhysics physics,
-    bool isCustomFeedback = false,
-    bool isCustomChildWhenDragging = false,
-    @required Function onWillAccept,
-    @required Function onReorder,
-    EdgeInsetsGeometry padding,
-    @required SliverGridDelegate gridDelegate,
-    @required IndexedWidgetBuilder itemBuilder,
-    int itemCount,
-    bool addAutomaticKeepAlives = true,
-    bool addRepaintBoundaries = true,
-    bool addSemanticIndexes = true,
-    double cacheExtent,
-    int semanticChildCount,
-    DragStartBehavior dragStartBehavior = DragStartBehavior.start,
-    ScrollViewKeyboardDismissBehavior keyboardDismissBehavior =
-        ScrollViewKeyboardDismissBehavior.manual,
-    Function feedback,
-    Function childWhenDragging,
-  })  : assert(itemBuilder != null &&
+  DragAndDropGridView.horizontal(
+      {Key key,
+      bool reverse = false,
+      ScrollController controller,
+      bool primary,
+      ScrollPhysics physics,
+      bool isCustomFeedback = false,
+      bool isCustomChildWhenDragging = false,
+      @required Function onWillAccept,
+      @required Function onReorder,
+      EdgeInsetsGeometry padding,
+      @required SliverGridDelegate gridDelegate,
+      @required IndexedWidgetBuilder itemBuilder,
+      int itemCount,
+      bool addAutomaticKeepAlives = true,
+      bool addRepaintBoundaries = true,
+      bool addSemanticIndexes = true,
+      double cacheExtent,
+      int semanticChildCount,
+      DragStartBehavior dragStartBehavior = DragStartBehavior.start,
+      ScrollViewKeyboardDismissBehavior keyboardDismissBehavior =
+          ScrollViewKeyboardDismissBehavior.manual,
+      Function feedback,
+      Function childWhenDragging,
+      Function(DraggableDetails) onDragEnd,
+      Function(Velocity, Offset) onDraggableCanceled})
+      : assert(itemBuilder != null &&
             gridDelegate != null &&
             onReorder != null &&
             onWillAccept != null),
         super(
-          key: key,
-          reverse: reverse,
-          itemBuilder: itemBuilder,
-          onWillAccept: onWillAccept,
-          feedback: feedback,
-          onReorder: onReorder,
-          childWhenDragging: childWhenDragging,
-          controller: controller,
-          padding: padding,
-          semanticChildCount: semanticChildCount,
-          physics: physics,
-          addAutomaticKeepAlives: addAutomaticKeepAlives,
-          addRepaintBoundaries: addRepaintBoundaries,
-          addSemanticIndexes: addSemanticIndexes,
-          cacheExtent: cacheExtent,
-          itemCount: itemCount,
-          primary: primary,
-          isCustomFeedback: isCustomFeedback,
-          isCustomChildWhenDragging: isCustomChildWhenDragging,
-          gridDelegate: gridDelegate,
-          dragStartBehavior: dragStartBehavior,
-          keyboardDismissBehavior: keyboardDismissBehavior,
-          isVertical: false,
-        );
+            key: key,
+            reverse: reverse,
+            itemBuilder: itemBuilder,
+            onWillAccept: onWillAccept,
+            feedback: feedback,
+            onReorder: onReorder,
+            childWhenDragging: childWhenDragging,
+            controller: controller,
+            padding: padding,
+            semanticChildCount: semanticChildCount,
+            physics: physics,
+            addAutomaticKeepAlives: addAutomaticKeepAlives,
+            addRepaintBoundaries: addRepaintBoundaries,
+            addSemanticIndexes: addSemanticIndexes,
+            cacheExtent: cacheExtent,
+            itemCount: itemCount,
+            primary: primary,
+            isCustomFeedback: isCustomFeedback,
+            isCustomChildWhenDragging: isCustomChildWhenDragging,
+            gridDelegate: gridDelegate,
+            dragStartBehavior: dragStartBehavior,
+            keyboardDismissBehavior: keyboardDismissBehavior,
+            isVertical: false,
+            onDragEnd: onDragEnd,
+            onDraggableCanceled: onDraggableCanceled);
 
   /// To achive the sticky header in gridview just call this stickyHeader constructor.
 
@@ -177,136 +183,40 @@ class DragAndDropGridView extends MainGridView {
   /// this [onReorder] have the old index and new index. Called when an acceptable piece of data was dropped over this grid child.
   /// [onWillAccept] this funciton allows you to validate if you want to accept the change in the order of the gridViewItems.
   ///  If you always want to accept the change simply return true
-  DragAndDropGridView.stickyHeader({
-    Key key,
-    bool reverse = false,
-    ScrollController controller,
-    bool primary,
-    ScrollPhysics physics,
-    bool isCustomFeedback = false,
-    bool isCustomChildWhenDragging = false,
-    @required Function onWillAccept,
-    Function onWillAcceptHeader,
-    @required IndexedWidgetBuilder itemBuilderHeader,
-    bool allHeaderChildNonDraggable = false,
-    SliverGridDelegate headerGridDelegate,
-    @required Function onReorder,
-    Function onReorderHeader,
-    int headerItemCount,
-    EdgeInsetsGeometry headerPadding,
-    EdgeInsetsGeometry padding,
-    @required SliverGridDelegate gridDelegate,
-    @required IndexedWidgetBuilder itemBuilder,
-    int itemCount,
-    bool addAutomaticKeepAlives = true,
-    bool addRepaintBoundaries = true,
-    bool addSemanticIndexes = true,
-    double cacheExtent,
-    int semanticChildCount,
-    DragStartBehavior dragStartBehavior = DragStartBehavior.start,
-    ScrollViewKeyboardDismissBehavior keyboardDismissBehavior =
-        ScrollViewKeyboardDismissBehavior.manual,
-    Function feedback,
-    Function childWhenDragging,
-  })  : assert(itemBuilder != null &&
-            gridDelegate != null &&
-            onReorder != null &&
-            onWillAccept != null &&
-            itemBuilderHeader != null),
-        super(
-          key: key,
-          reverse: reverse,
-          itemBuilder: itemBuilder,
-          onWillAccept: onWillAccept,
-          feedback: feedback,
-          onReorder: onReorder,
-          onReorderHeader: onReorderHeader,
-          onWillAcceptHeader: onWillAcceptHeader,
-          childWhenDragging: childWhenDragging,
-          controller: controller,
-          padding: padding,
-          semanticChildCount: semanticChildCount,
-          physics: physics,
-          addAutomaticKeepAlives: addAutomaticKeepAlives,
-          addRepaintBoundaries: addRepaintBoundaries,
-          addSemanticIndexes: addSemanticIndexes,
-          cacheExtent: cacheExtent,
-          itemCount: itemCount,
-          primary: primary,
-          isCustomFeedback: isCustomFeedback,
-          isCustomChildWhenDragging: isCustomChildWhenDragging,
-          gridDelegate: gridDelegate,
-          dragStartBehavior: dragStartBehavior,
-          keyboardDismissBehavior: keyboardDismissBehavior,
-          itemBuilderHeader: itemBuilderHeader,
-          isStickyHeader: true,
-          allHeaderChildNonDraggable: allHeaderChildNonDraggable,
-          headerPadding: headerPadding,
-          headerGridDelegate: headerGridDelegate,
-          headerItemCount: headerItemCount,
-        );
-
-  /// To achive the sticky header in horizontal gridview just call this horizontalStickyHeader constructor.
-
-  /// By Default allHeaderChildNonDraggable is set to false making all header draggable.
-
-  /// [onWillAcceptHeader] (Implement your logic on accepting and rejecting the drop of an header element),
-
-  /// [onReorderHeader] (implement your logic for reodering and reindexing the elements)
-
-  /// And if you want the header to be non-draggable element simple set [allHeaderChildNonDraggable] to true.
-
-  ///  [itemBuilderHeader] will be called only with indices greater than or equal to
-  ///
-  ///
-  /// Providing a non-null `itemCount` improves the ability of the [GridView] to
-  /// estimate the maximum scroll extent.
-  ///
-  /// `itemBuilder` will be called only with indices greater than or equal to
-  /// zero and less than `itemCount`.
-  ///
-  /// The [gridDelegate] argument must not be null.
-  ///
-  /// The `addAutomaticKeepAlives` argument corresponds to the
-  /// [SliverChildBuilderDelegate.addAutomaticKeepAlives] property. The
-  /// `addRepaintBoundaries` argument corresponds to the
-  /// [SliverChildBuilderDelegate.addRepaintBoundaries] property. Both must not
-  /// be null.
-  /// this [onReorder] have the old index and new index. Called when an acceptable piece of data was dropped over this grid child.
-  /// [onWillAccept] this funciton allows you to validate if you want to accept the change in the order of the gridViewItems.
-  ///  If you always want to accept the change simply return true
-  DragAndDropGridView.horizontalStickyHeader({
-    Key key,
-    bool reverse = false,
-    ScrollController controller,
-    bool primary,
-    ScrollPhysics physics,
-    bool isCustomFeedback = false,
-    bool isCustomChildWhenDragging = false,
-    @required Function onWillAccept,
-    Function onWillAcceptHeader,
-    @required IndexedWidgetBuilder itemBuilderHeader,
-    bool allHeaderChildNonDraggable = false,
-    SliverGridDelegate headerGridDelegate,
-    @required Function onReorder,
-    Function onReorderHeader,
-    int headerItemCount,
-    EdgeInsetsGeometry headerPadding,
-    EdgeInsetsGeometry padding,
-    @required SliverGridDelegate gridDelegate,
-    @required IndexedWidgetBuilder itemBuilder,
-    int itemCount,
-    bool addAutomaticKeepAlives = true,
-    bool addRepaintBoundaries = true,
-    bool addSemanticIndexes = true,
-    double cacheExtent,
-    int semanticChildCount,
-    DragStartBehavior dragStartBehavior = DragStartBehavior.start,
-    ScrollViewKeyboardDismissBehavior keyboardDismissBehavior =
-        ScrollViewKeyboardDismissBehavior.manual,
-    Function feedback,
-    Function childWhenDragging,
-  })  : assert(itemBuilder != null &&
+  DragAndDropGridView.stickyHeader(
+      {Key key,
+      bool reverse = false,
+      ScrollController controller,
+      bool primary,
+      ScrollPhysics physics,
+      bool isCustomFeedback = false,
+      bool isCustomChildWhenDragging = false,
+      @required Function onWillAccept,
+      Function onWillAcceptHeader,
+      @required IndexedWidgetBuilder itemBuilderHeader,
+      bool allHeaderChildNonDraggable = false,
+      SliverGridDelegate headerGridDelegate,
+      @required Function onReorder,
+      Function onReorderHeader,
+      int headerItemCount,
+      EdgeInsetsGeometry headerPadding,
+      EdgeInsetsGeometry padding,
+      @required SliverGridDelegate gridDelegate,
+      @required IndexedWidgetBuilder itemBuilder,
+      int itemCount,
+      bool addAutomaticKeepAlives = true,
+      bool addRepaintBoundaries = true,
+      bool addSemanticIndexes = true,
+      double cacheExtent,
+      int semanticChildCount,
+      DragStartBehavior dragStartBehavior = DragStartBehavior.start,
+      ScrollViewKeyboardDismissBehavior keyboardDismissBehavior =
+          ScrollViewKeyboardDismissBehavior.manual,
+      Function feedback,
+      Function childWhenDragging,
+      Function(DraggableDetails) onDragEnd,
+      Function(Velocity, Offset) onDraggableCanceled})
+      : assert(itemBuilder != null &&
             gridDelegate != null &&
             onReorder != null &&
             onWillAccept != null &&
@@ -342,5 +252,108 @@ class DragAndDropGridView extends MainGridView {
             headerPadding: headerPadding,
             headerGridDelegate: headerGridDelegate,
             headerItemCount: headerItemCount,
-            isVertical: false);
+            onDragEnd: onDragEnd,
+            onDraggableCanceled: onDraggableCanceled);
+
+  /// To achive the sticky header in horizontal gridview just call this horizontalStickyHeader constructor.
+
+  /// By Default allHeaderChildNonDraggable is set to false making all header draggable.
+
+  /// [onWillAcceptHeader] (Implement your logic on accepting and rejecting the drop of an header element),
+
+  /// [onReorderHeader] (implement your logic for reodering and reindexing the elements)
+
+  /// And if you want the header to be non-draggable element simple set [allHeaderChildNonDraggable] to true.
+
+  ///  [itemBuilderHeader] will be called only with indices greater than or equal to
+  ///
+  ///
+  /// Providing a non-null `itemCount` improves the ability of the [GridView] to
+  /// estimate the maximum scroll extent.
+  ///
+  /// `itemBuilder` will be called only with indices greater than or equal to
+  /// zero and less than `itemCount`.
+  ///
+  /// The [gridDelegate] argument must not be null.
+  ///
+  /// The `addAutomaticKeepAlives` argument corresponds to the
+  /// [SliverChildBuilderDelegate.addAutomaticKeepAlives] property. The
+  /// `addRepaintBoundaries` argument corresponds to the
+  /// [SliverChildBuilderDelegate.addRepaintBoundaries] property. Both must not
+  /// be null.
+  /// this [onReorder] have the old index and new index. Called when an acceptable piece of data was dropped over this grid child.
+  /// [onWillAccept] this funciton allows you to validate if you want to accept the change in the order of the gridViewItems.
+  ///  If you always want to accept the change simply return true
+  DragAndDropGridView.horizontalStickyHeader(
+      {Key key,
+      bool reverse = false,
+      ScrollController controller,
+      bool primary,
+      ScrollPhysics physics,
+      bool isCustomFeedback = false,
+      bool isCustomChildWhenDragging = false,
+      @required Function onWillAccept,
+      Function onWillAcceptHeader,
+      @required IndexedWidgetBuilder itemBuilderHeader,
+      bool allHeaderChildNonDraggable = false,
+      SliverGridDelegate headerGridDelegate,
+      @required Function onReorder,
+      Function onReorderHeader,
+      int headerItemCount,
+      EdgeInsetsGeometry headerPadding,
+      EdgeInsetsGeometry padding,
+      @required SliverGridDelegate gridDelegate,
+      @required IndexedWidgetBuilder itemBuilder,
+      int itemCount,
+      bool addAutomaticKeepAlives = true,
+      bool addRepaintBoundaries = true,
+      bool addSemanticIndexes = true,
+      double cacheExtent,
+      int semanticChildCount,
+      DragStartBehavior dragStartBehavior = DragStartBehavior.start,
+      ScrollViewKeyboardDismissBehavior keyboardDismissBehavior =
+          ScrollViewKeyboardDismissBehavior.manual,
+      Function feedback,
+      Function childWhenDragging,
+      Function(DraggableDetails) onDragEnd,
+      Function(Velocity, Offset) onDraggableCanceled})
+      : assert(itemBuilder != null &&
+            gridDelegate != null &&
+            onReorder != null &&
+            onWillAccept != null &&
+            itemBuilderHeader != null),
+        super(
+            key: key,
+            reverse: reverse,
+            itemBuilder: itemBuilder,
+            onWillAccept: onWillAccept,
+            feedback: feedback,
+            onReorder: onReorder,
+            onReorderHeader: onReorderHeader,
+            onWillAcceptHeader: onWillAcceptHeader,
+            childWhenDragging: childWhenDragging,
+            controller: controller,
+            padding: padding,
+            semanticChildCount: semanticChildCount,
+            physics: physics,
+            addAutomaticKeepAlives: addAutomaticKeepAlives,
+            addRepaintBoundaries: addRepaintBoundaries,
+            addSemanticIndexes: addSemanticIndexes,
+            cacheExtent: cacheExtent,
+            itemCount: itemCount,
+            primary: primary,
+            isCustomFeedback: isCustomFeedback,
+            isCustomChildWhenDragging: isCustomChildWhenDragging,
+            gridDelegate: gridDelegate,
+            dragStartBehavior: dragStartBehavior,
+            keyboardDismissBehavior: keyboardDismissBehavior,
+            itemBuilderHeader: itemBuilderHeader,
+            isStickyHeader: true,
+            allHeaderChildNonDraggable: allHeaderChildNonDraggable,
+            headerPadding: headerPadding,
+            headerGridDelegate: headerGridDelegate,
+            headerItemCount: headerItemCount,
+            isVertical: false,
+            onDragEnd: onDragEnd,
+            onDraggableCanceled: onDraggableCanceled);
 }

--- a/lib/gridorbiter.dart
+++ b/lib/gridorbiter.dart
@@ -35,7 +35,9 @@ class MainGridView extends StatefulWidget {
       this.isCustomChildWhenDragging,
       @required this.gridDelegate,
       this.dragStartBehavior = DragStartBehavior.start,
-      this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual});
+      this.keyboardDismissBehavior = ScrollViewKeyboardDismissBehavior.manual,
+      this.onDragEnd,
+      this.onDraggableCanceled});
 
   final Key key;
 
@@ -60,6 +62,12 @@ class MainGridView extends StatefulWidget {
   // This method onReorder has two parameters oldIndex and newIndex
   final Function onReorder;
   final Function onReorderHeader;
+
+  // This method onDragEnd is called at the end of any dragging
+  final Function(DraggableDetails) onDragEnd;
+
+  // The method onDraggableCanceled is called, when dragging is ended, but onReorder is not called
+  final Function(Velocity, Offset) onDraggableCanceled;
 
   final EdgeInsetsGeometry padding;
   final int headerItemCount;
@@ -206,13 +214,17 @@ class _MainGridViewState extends State<MainGridView> {
           ? widget.childWhenDragging(pos)
           : mainWidget,
       axis: isFromArrange
-          ? widget.isVertical ? Axis.horizontal : Axis.vertical
+          ? widget.isVertical
+              ? Axis.horizontal
+              : Axis.vertical
           : null,
       onDragStarted: () {
         setState(() {
           _isDragStart = true;
         });
       },
+      onDraggableCanceled: widget.onDraggableCanceled,
+      onDragEnd: widget.onDragEnd,
       onDragCompleted: () {
         setState(() {
           _isDragStart = false;
@@ -308,8 +320,12 @@ class _MainGridViewState extends State<MainGridView> {
           _gridViewHeight = constraints.maxHeight;
           _gridViewWidth = constraints.maxWidth;
           return widget.isStickyHeader
-              ? widget.isVertical ? _tableBuilder() : _tableBuilderHorizontal()
-              : widget.header == null ? _dragAndDropGrid() : _headerChild();
+              ? widget.isVertical
+                  ? _tableBuilder()
+                  : _tableBuilderHorizontal()
+              : widget.header == null
+                  ? _dragAndDropGrid()
+                  : _headerChild();
         }),
         !_isDragStart
             ? SizedBox()

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,49 +7,49 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,21 +66,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.8"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -92,56 +92,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.5"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.17"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.9.0-14.0.dev <3.0.0"
-  flutter: ">=1.17.0 <2.0.0"
+  dart: ">=2.12.0-0.0 <3.0.0"
+  flutter: ">=1.17.0"


### PR DESCRIPTION
When you look at the "Example #4: DragAndDropGridView with hover effect (Reorderable)", you can see, that there can be a situation, when the user drops the item out of the GridView. In that case, onReorder is not called, and the draggable item remains "hovered". That is why these added methods can be userful to clean all changes